### PR TITLE
-ハッシュ変換に\0を含む文字列を渡すと無限ループする問題に対応(@762)

### DIFF
--- a/hi_unit/hima_variable_ex.pas
+++ b/hi_unit/hima_variable_ex.pas
@@ -2938,17 +2938,18 @@ end;
 
 procedure THiHash.SetFromString(const Value: AnsiString);
 var
-  p, p_last: PAnsiChar;
+  p: PAnsiChar;
   n, v: AnsiString;
   hv: PHiValue;
+  l: Integer;
 begin
   p := PAnsiChar(Value);
-  p_last := p + Length(Value);
-  while p < p_last do
+  l := Length(Value);
+  while l > 0 do
   begin
-    v := getTokenCh(p, [#13,#10]);
-    if p^ = #13 then Inc(p);
-    if p^ = #10 then Inc(p);
+    v := getTokenChB(p, l, [#13,#10]);
+    if p^ = #13 then begin Inc(p);Dec(l); end;
+    if p^ = #10 then begin Inc(p);Dec(l); end;
     n := getToken_s(v, '=');
     if (TrimA(v) = '')and(TrimA(n) = '') then Continue; // 不要なキーは作らない
     // key = n , value = v

--- a/hi_unit/unit_string.pas
+++ b/hi_unit/unit_string.pas
@@ -45,6 +45,9 @@ function getToken_sU(var s: string; splitter: string): string;
 // 特定の区切り文字までを取得する（区切り文字は削除する）
 function getTokenChW(var p: PAnsiChar; ch: TChars): AnsiString;
 
+// 特定の区切り文字までを取得する（区切り文字は削除する）対バイナリ用
+function getTokenChB(var p: PAnsiChar; var l: integer;ch: TChars): AnsiString;
+
 
 //------------------------------------------------------------------------------
 // 検索取り出し
@@ -472,6 +475,24 @@ begin
     end;
 
     Result := Result + p^; Inc(p);
+  end;
+end;
+
+// 特定の区切り文字までを取得する（区切り文字は削除する）
+function getTokenChB(var p: PAnsiChar; var l: Integer;ch: TChars): AnsiString;
+begin
+  Result := '';
+  while l > 0 do
+  begin
+    if p^ in ch then
+    begin
+      Inc(p);
+      Dec(l);
+      Break;
+    end;
+
+    Result := Result + p^; Inc(p);
+    Dec(l);
   end;
 end;
 


### PR DESCRIPTION
バグ・要望掲示板の@762に関する修正。
ハッシュ変換を行う際に文字列中に「\0」が含まれていると、その位置でGetTokenChが停止してしまい、文字列の最後まで到達できずに無限ループする現象に対応。
（文字列の長さを、String.Lengthと、null-terminateで混在して判定しているのが原因）
バイナリ用のGettokenChを作成して、開始ポインタと区切り文字の配列に加えて、長さを渡すようにして対応。
