### PR TITLE
タスクトレイバルーンにアプリケーションアイコンとフォルダ作成の対応(@755,@764)

### DIFF
--- a/frmNakoU.pas
+++ b/frmNakoU.pas
@@ -1649,6 +1649,9 @@ begin
 end;
 
 procedure TfrmNako.ShowBalloon(message:String);
+var
+  trayIconInfo   : TIconInfo;
+  tBM :tagBitmap;
 begin
   if not IsLiveTasktray then exit;
   if NotifyIconSize = 88 then exit;
@@ -1677,6 +1680,28 @@ begin
           hBalloonIcon := Self.Icon.Handle
         else
           hBalloonIcon := Application.Icon.Handle;
+    if (dwInfoFlags and $0000000f) = $00000004 then // NIIF_USER=$00000004
+    begin
+      if NotifyIconSize = 508 then
+        GetIconInfo(hBalloonIcon, trayIconInfo)
+      else
+        GetIconInfo(hIcon, trayIconInfo);
+      GetObject(trayIconInfo.hbmColor, Sizeof(tBM), @tBM);
+      if (GetSystemMetrics(SM_CXSMICON) = tBM.bmWidth) and
+         (GetSystemMetrics(SM_CYSMICON) = tBM.bmHeight) then
+        dwInfoFlags := dwInfoFlags and $ffffffdf  // NIIF_LARGE_ICON=$00000020
+      else
+      if (GetSystemMetrics(SM_CXICON) = tBM.bmWidth) and
+         (GetSystemMetrics(SM_CYICON) = tBM.bmHeight) then
+        dwInfoFlags := dwInfoFlags or  $00000020  // NIIF_LARGE_ICON=$00000020
+      else
+      begin
+        dwInfoFlags := dwInfoFlags or  $fffffffb; // NIIF_USER=$00000004
+        dwInfoFlags := dwInfoFlags and $ffffffdf; // NIIF_LARGE_ICON=$00000020
+        if NotifyIconSize = 508 then
+          hBalloonIcon := 0;
+      end;
+    end;
     StrLCopy(@szTip[0],PChar(Self.Caption), 127);
     if bBalloonHideTitle then
       StrLCopy(@szInfoTitle[0],PChar(''), 63)
@@ -1691,6 +1716,9 @@ begin
 end;
 
 procedure TfrmNako.hideBalloon();
+var
+  trayIconInfo   : TIconInfo;
+  tBM :tagBitmap;
 begin
   if not IsLiveTasktray then exit;
   if NotifyIconSize = 88 then exit;
@@ -1709,6 +1737,28 @@ begin
       hIcon := Self.Icon.Handle
     else
       hIcon := Application.Icon.Handle;
+    if (dwInfoFlags and $0000000f) = $00000004 then // NIIF_USER=$00000004
+    begin
+      if NotifyIconSize = 508 then
+        GetIconInfo(hBalloonIcon, trayIconInfo)
+      else
+        GetIconInfo(hIcon, trayIconInfo);
+      GetObject(trayIconInfo.hbmColor, Sizeof(tBM), @tBM);
+      if (GetSystemMetrics(SM_CXSMICON) = tBM.bmWidth) and
+         (GetSystemMetrics(SM_CYSMICON) = tBM.bmHeight) then
+        dwInfoFlags := dwInfoFlags and $ffffffdf  // NIIF_LARGE_ICON=$00000020
+      else
+      if (GetSystemMetrics(SM_CXICON) = tBM.bmWidth) and
+         (GetSystemMetrics(SM_CYICON) = tBM.bmHeight) then
+        dwInfoFlags := dwInfoFlags or  $00000020  // NIIF_LARGE_ICON=$00000020
+      else
+      begin
+        dwInfoFlags := dwInfoFlags or  $fffffffb; // NIIF_USER=$00000004
+        dwInfoFlags := dwInfoFlags and $ffffffdf; // NIIF_LARGE_ICON=$00000020
+        if NotifyIconSize = 508 then
+          hBalloonIcon := 0;
+      end;
+    end;
     StrLCopy(@szTip[0],PChar(Self.Caption), 127);
     StrLCopy(@szInfoTitle[0],PChar(''), 63);
     StrLCopy(@szInfo[0],PChar(''), 255);

--- a/hi_unit/dll_file_function.pas
+++ b/hi_unit/dll_file_function.pas
@@ -543,7 +543,7 @@ begin
   // (2) データの処理
   try
     a := hi_str(s);
-    if Pos('\', a) > 0  then ForceDirectories(a)
+    if PosA('\', a) > 0  then ForceDirectories(a)
                         else MkDir(a);
   except on e: Exception do
     raise Exception.Create('フォルダ『' + hi_str(s) + '』が作成できません。理由は,' + e.Message);
@@ -717,7 +717,7 @@ begin
   if s=nil then path := CheckPathYen( GetCurrentDir )
            else path := hi_str(s);
 
-  if Copy(path, Length(path), 1) = '\' then path := path + '*';
+  if CopyA(path, JLength(path), 1) = '\' then path := path + '*';
 
   // (2) データの処理
   g := EnumDirs(path);
@@ -1019,8 +1019,8 @@ begin
   b := nako_getFuncArg(args, 1);
   sa := hi_str(a);
   sb := hi_str(b);
-  if Copy(sa,Length(sa),1) = '\' then System.Delete(sa,Length(sa),1);
-  if Copy(sb,Length(sb),1) = '\' then System.Delete(sb,Length(sb),1);
+  if CopyA(sa,JLength(sa),1) = '\' then System.Delete(sa,Length(sa),1);
+  if CopyA(sb,JLength(sb),1) = '\' then System.Delete(sb,Length(sb),1);
 
   if DirectoryExists(sb) = False then
   begin


### PR DESCRIPTION
タスクトレイバルーンにアプリケーションアイコンを指定した場合、以下のように動作。
・ラージアイコンオプションの指定を自動設定し、ユーザでの指定を無視。
・アプリケーションにバルーンに使用不能なサイズのアイコンが指定されている場合、
　バルーンへのアイコンの表示を外す。
アイコンのリサイズ等は、リソースの解放管理が手間そうなのでやってません。
フォルダ作成の対応はPosをPosAに変更。
また、末尾\チェックにcopyとlengthを使用している部分をcopyaとjlengthに修正。
