### PR TITLE
エクセル画像挿入命令が常に画像を保持するよう修正(@766)

### DIFF
--- a/hi_unit/dll_office_function.pas
+++ b/hi_unit/dll_office_function.pas
@@ -338,7 +338,16 @@ var
   f: string;
 begin
   f := getArgStr(h, 0);
-  excel.InsertPic(f);
+  excel.addPicture(f, false);
+  Result := nil;
+end;
+
+function excel_insertPicLink(h: DWORD): PHiValue; stdcall;
+var
+  f: string;
+begin
+  f := getArgStr(h, 0);
+  excel.addPicture(f, true);
   Result := nil;
 end;
 
@@ -2054,6 +2063,7 @@ begin
   AddFunc  ('エクセル選択シェイプサイズ設定','W,Hに|Hへ', 4734, excel_shapeResize,'Excelの選択中シェイプのサイズをW,Hに変更する。','えくせるせんたくしぇいぷたくさいずせってい');
   AddFunc  ('エクセル選択シェイプ移動','X,Yに|Yへ', 4735, excel_shapeMove,'Excelの選択中シェイプの位置をX,Yに変更する。','えくせるせんたくしぇいぷいどう');
   AddFunc  ('エクセルシェイプ選択','{=?}Sの', 4737, excel_selectShape,'Excelで名前Sのシェイプを選択する。','えくせるしぇいぷせんたく');
+  AddFunc  ('エクセル画像リンク挿入','Fの', -1, excel_insertPicLink,'Excelの選択中セルの場所に画像Fをリンクで挿入する。','えくせるがぞうりんくそうにゅう');
 
   //-ワード(Word)
   AddFunc  ('ワード起動','{=1}Aで', 4330, word_open,'可視A(オンかオフ)でワードを起動する','わーどきどう');

--- a/hi_unit/unit_office.pas
+++ b/hi_unit/unit_office.pas
@@ -93,6 +93,7 @@ type
     function getLastCol(row:string):Integer;
     procedure UniqueRow(col:string);
     procedure InsertPic(f: string);
+    procedure AddPicture(f: string; asLink: Boolean);
     procedure SetShapeSize(w, h:Integer);
     procedure MoveShape(x, y: Integer);
     procedure SelectShape(name: string);
@@ -1109,6 +1110,21 @@ var
 begin
   E_WorkSheet := E_Application.ActiveSheet;
   r := E_WorkSheet.Pictures.Insert(f);
+  r.Select();
+  r := Unassigned;
+end;
+procedure TKExcel.AddPicture(f: string; asLink: Boolean);
+var
+  r:Variant;
+begin
+  E_WorkSheet := E_Application.ActiveSheet;
+  r := E_WorkSheet.Shapes.AddPicture(f,
+    asLink,       // FileToLink
+    not asLink, // SaveWithDocument
+    E_Application.Selection.Left, E_Application.Selection.Top,
+    50,50);
+  r.ScaleHeight(1,true);
+  r.ScaleWidth(1,true);
   r.Select();
   r := Unassigned;
 end;


### PR DESCRIPTION
エクセル画像挿入がExcel2010以降でリンクになっていたのを修正。
あわせて、エクセル画像リンク挿入命令追加。
